### PR TITLE
decode object name before doing any operation

### DIFF
--- a/thumbnail.js
+++ b/thumbnail.js
@@ -39,7 +39,7 @@ const imageType = 'image/jpg';
 // Wait on notification from the poller.
 poller.on('notification', record => {
     var bname = record.s3.bucket.name;
-    var oname = record.s3.object.key;
+    var oname = decodeURIComponent(record.s3.object.key);
     mc.getObject(bname, oname,
                  function(err, dataStream) {
                      if (err) {


### PR DESCRIPTION
Notification will return object name in encoded form,
it should be decoded before doing any action.

Fixes #2