### PR TITLE
Update URL for sharp documentation

### DIFF
--- a/thumbnail-webhook.js
+++ b/thumbnail-webhook.js
@@ -46,7 +46,7 @@ var webhookConfig = function() {
 var transformer = sharp().resize(40, 40)
 
 // Sharp defaults to jpeg, to use other formats use
-// sharp() documentation at http://sharp.dimens.io/en/stable/
+// sharp() documentation at https://sharp.pixelplumbing.com/
 const imageType = 'image/jpg';
 
 app.use(bodyParser.json()); // for parsing application/json

--- a/thumbnail.js
+++ b/thumbnail.js
@@ -32,7 +32,7 @@ console.log("Listening for events on", "\""+mcConfig.bucket+"\"");
 var transformer = sharp().resize(40, 40)
 
 // Sharp defaults to jpeg, to use other formats use
-// sharp() documentation at http://sharp.dimens.io/en/stable/
+// sharp() documentation at https://sharp.pixelplumbing.com/
 
 const imageType = 'image/jpg';
 


### PR DESCRIPTION
The current URL is dead and seems to redirect to some sketchy pages. According to the repo the current official URL is https://sharp.pixelplumbing.com/ (see https://github.com/lovell/sharp)